### PR TITLE
Add note regarding ARA reports support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Set up Aggregation Service for Aggregatable Reports
 
+**[NOTE] The latest aggregatable reports generated with Chrome version 104+ (currently available in Beta) are not yet compatible with the `LocalTestingTool` or the Aggregation Service running on AWS. We will update both shortly to support the new report format.**
+
 This repository contains instructions and scripts to set up and test
 the Aggregation Service for [Aggregatable Reports](https://github.com/WICG/conversion-measurement-api/blob/main/AGGREGATION_SERVICE_TEE.md#aggregatable-reports)
 locally and on Amazon Web Services [Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/).


### PR DESCRIPTION
The Attribution Reporting API aggregatable reports format changed with [https://github.com/WICG/attribution-reporting-api/pull/471](https://github.com/WICG/attribution-reporting-api/pull/471) rolled out in Chrome 104 (currently available on the Beta channel).

This change adds a note that the new format of the aggregatable reports is currently not supported by the implementation of the aggregation service (both `LocalTestingTool` and deployment on AWS).